### PR TITLE
Fix some errors with x86_64 gcc

### DIFF
--- a/Src/Main.cpp
+++ b/Src/Main.cpp
@@ -129,7 +129,7 @@ static void crash_flush() {
     fsync(crashLogFD);
 }
 
-#ifdef __i386__
+#if (defined(__i386__) || defined(__x86_64__))
 
 // Register context dumper for ia32 / x64:
 #if __WORDSIZE == 64


### PR DESCRIPTION
- x86_64 gcc predefines macro `__x86_64__` instead of `__i386__`

Open-webOS-DCO-1.0-Signed-off-by: Weiwen Zhao panda.hust@gmail.com
