### PR TITLE
emulator.pri: use the same config for qemux86-64 as qemux86 has

### DIFF
--- a/emulator.pri
+++ b/emulator.pri
@@ -18,6 +18,9 @@
 
 MACHINE_NAME = $$(MACHINE)
 
+contains(MACHINE_NAME, "qemux86-64") {
+    CONFIG_BUILD += nyx webosemulator
+}
 contains(MACHINE_NAME, "qemux86") {
     CONFIG_BUILD += nyx webosemulator
 }


### PR DESCRIPTION
Open-webOS-DCO-1.0-Signed-off-by: Martin Jansa Martin.Jansa@gmail.com
