### PR TITLE
Add compilation and runtime configuration support for the tuna machine

### DIFF
--- a/conf/launcher3/launcher_icon_layoutsettings-tuna.conf
+++ b/conf/launcher3/launcher_icon_layoutsettings-tuna.conf
@@ -1,0 +1,28 @@
+# @@@LICENSE
+#
+#      Copyright (c) 2011-2012 Hewlett-Packard Development Company, L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# LICENSE@@@
+[ReorderableLayout]
+RowTopMarginInPixels=32
+InterRowSpaceInPixels=0
+IconHorizontalSpaceAdjustInPixels=28
+RowLeftMarginInPixels=32
+EmptyPageTextBoxWidthPx=350
+EmptyPageTextBoxCenterVerticalOffsetPx=190
+EmptyPageTextFontSizePx=18
+MaxIconsPerRow=4
+FixedIconCellWidth=142
+FixedIconCellHeight=200

--- a/conf/luna-tuna.conf
+++ b/conf/luna-tuna.conf
@@ -1,0 +1,55 @@
+# @@@LICENSE
+#
+#      Copyright (c) 2010-2012 Hewlett-Packard Development Company, L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# LICENSE@@@
+[LaunchAtBoot]
+Applications=com.palm.app.phone;com.palm.app.email
+
+[General]
+ShowReticle=true
+DisplayWidth=720
+DisplayHeight=1280
+
+[UI]
+TabletUi=false
+DisplayUiRotates=true
+HomeButtonOrientationAngle=0
+ActiveCardWindowRatio=0.50
+NonActiveCardWindowRatio=0.45
+CardGroupRotFactor=90
+GapBetweenCardGroups=20
+UIScale=0.4375
+TextScale=1.75
+LayoutScale=1.75
+IMEScale=1.5
+WebAppScale=1.75
+
+[Display]
+TurnOffAccelerometerWhenDimmed=false
+BrightnessOutdoorScale=255
+# We don't have support for ambient light sensor yet
+EnableALS=false
+
+[VirtualKeyboard]
+VirtualKeyboardEnabled=true
+
+[CoreNavi]
+# Device does not have a lightbar
+EnableLightBar=false
+
+[VirtualCoreNavi]
+VirtualCoreNaviEnabled=true
+VirtualCoreNaviHeight=64

--- a/device-known.pri
+++ b/device-known.pri
@@ -63,3 +63,10 @@ contains(MACHINE_NAME, "opal") {
 	CONFIG_BUILD += affinity haptics napp nyx hidlib webosdevice
     LIBS += -lqpalm
 }
+contains(MACHINE_NAME, "tuna") {
+    DEFINES += MACHINE_TUNA HAS_DISPLAY_TIMEOUT
+    TARGET_TYPE = TARGET_DEVICE
+    CONFIG_BUILD += webosdevice nyx
+    CONFIG_BUILD += opengl
+    LIBS += -lqpalm
+}


### PR DESCRIPTION
The added configuration files contains some webOS-ports specific options related to the
ongoing UI scaling work which will be submitted upstream later.

Open-webOS-DCO-1.0-Signed-off-by: Simon Busch morphis@gravedo.de
