### PR TITLE
MemoryMonitor: use /proc/*/oom_score_adj rather than /proc/*/oom_adj

### DIFF
--- a/Src/base/MemoryMonitor.h
+++ b/Src/base/MemoryMonitor.h
@@ -75,7 +75,9 @@ private:
 	int getCurrentRssUsage() const;
 
 	int getProcessMemInfo(pid_t pid);
-	
+
+	void adjustOomScore();
+
 #if defined(HAS_MEMCHUTE)
     static void memchuteCallback(MemchuteThreshold threshold);
 	void memchuteStateChanged();


### PR DESCRIPTION
On newer kernels /proc/_/oom_adj is deprecated and should not be used anymore. As Open
webOS requires at least a linux 3.3 kernel this changes the use to the new
/proc/_/oom_score_adj entry.

Running a 3.0.49 kernel together with LunaSysMgr shows the following in kernel log:

[   28.763610] WebAppMgr (2090): /proc/2090/oom_adj is deprecated, please use
/proc/2090/oom_score_adj instead.

Open-webOS-DCO-1.0-Signed-off-by: Simon Busch morphis@gravedo.de
