### PR TITLE
System Menu: Use explicit font definitions for WiFi/BT/VPN

### DIFF
--- a/uiComponents/SystemMenu/BluetoothElement.qml
+++ b/uiComponents/SystemMenu/BluetoothElement.qml
@@ -172,6 +172,7 @@ Drawer {
                         text: runtime.getLocalizedString("init");
                         color: "#AAA";
                         font.pixelSize: 13
+                        font.family: "Prelude"
                         font.capitalization: Font.AllUppercase
                     }
                 }

--- a/uiComponents/SystemMenu/VpnElement.qml
+++ b/uiComponents/SystemMenu/VpnElement.qml
@@ -93,6 +93,7 @@ Drawer {
                         elide: Text.ElideRight;
                         color: "#AAA";
                         font.pixelSize: 13
+                        font.family: "Prelude"
                         font.capitalization: Font.AllUppercase
                     }
                 }

--- a/uiComponents/SystemMenu/WiFiElement.qml
+++ b/uiComponents/SystemMenu/WiFiElement.qml
@@ -170,6 +170,7 @@ Drawer {
                         elide: Text.ElideRight;
                         color: "#AAA";
                         font.pixelSize: 13
+                        font.family: "Prelude"
                         font.capitalization: Font.AllUppercase
                     }
                 }


### PR DESCRIPTION
Implicit definitions break when isis-fonts is installed and cause the system menu status text to display squares.
